### PR TITLE
Move proxy server tests to tests/integration/proxy/ directory

### DIFF
--- a/PROXY_INTEGRATION_SUMMARY.md
+++ b/PROXY_INTEGRATION_SUMMARY.md
@@ -40,7 +40,7 @@ This document summarizes the Webshare proxy integration added to tldwatch to avo
 6. **Comprehensive Examples**
    - `examples/proxy_usage.py`: Complete proxy usage examples
    - `examples/complete_proxy_example.py`: Full integration demonstration
-   - `setup_proxy_test.py`: Setup verification script
+   - `tests/integration/proxy/test_proxy_setup.py`: Setup verification script
 
 7. **Documentation**
    - `PROXY_SETUP.md`: Detailed setup instructions
@@ -48,7 +48,7 @@ This document summarizes the Webshare proxy integration added to tldwatch to avo
    - Updated `README.md` with proxy configuration section
 
 8. **Testing**
-   - `test_proxy_integration.py`: Comprehensive test suite
+   - `tests/integration/proxy/test_proxy_integration.py`: Comprehensive test suite
    - Tests for all proxy configuration scenarios
    - CLI integration testing
    - Error handling verification
@@ -130,8 +130,8 @@ tldwatch "https://www.youtube.com/watch?v=QAgR4uQ15rc"
 - `src/tldwatch/core/proxy_config.py`
 - `examples/proxy_usage.py`
 - `examples/complete_proxy_example.py`
-- `setup_proxy_test.py`
-- `test_proxy_integration.py`
+- `tests/integration/proxy/test_proxy_setup.py`
+- `tests/integration/proxy/test_proxy_integration.py`
 - `PROXY_SETUP.md`
 - `WEBSHARE_INTEGRATION.md`
 - `PROXY_INTEGRATION_SUMMARY.md`
@@ -154,15 +154,15 @@ The integration includes comprehensive testing:
 
 Run tests with:
 ```bash
-python test_proxy_integration.py
-python setup_proxy_test.py  # Requires actual credentials
+python tests/integration/proxy/test_proxy_integration.py
+python tests/integration/proxy/test_proxy_setup.py  # Requires actual credentials
 ```
 
 ## Next Steps for Users
 
 1. **Sign up for Webshare**: Get a residential proxy package
 2. **Set credentials**: Use environment variables or CLI options
-3. **Test setup**: Run `setup_proxy_test.py` to verify configuration
+3. **Test setup**: Run `tests/integration/proxy/test_proxy_setup.py` to verify configuration
 4. **Use in production**: Integrate with existing tldwatch workflows
 
 ## Backward Compatibility

--- a/WEBSHARE_INTEGRATION.md
+++ b/WEBSHARE_INTEGRATION.md
@@ -26,7 +26,7 @@ export OPENAI_API_KEY="your_openai_key"  # or other provider key
 
 ```bash
 cd tldwatch
-python setup_proxy_test.py
+python tests/integration/proxy/test_proxy_setup.py
 ```
 
 ### 4. Use with tldwatch
@@ -158,7 +158,7 @@ except SummarizerError as e:
 - `src/tldwatch/core/proxy_config.py`: Proxy configuration classes
 - `examples/proxy_usage.py`: Comprehensive proxy examples
 - `examples/complete_proxy_example.py`: Full integration example
-- `setup_proxy_test.py`: Setup verification script
+- `tests/integration/proxy/test_proxy_setup.py`: Setup verification script
 - `PROXY_SETUP.md`: Detailed proxy setup guide
 - `WEBSHARE_INTEGRATION.md`: This file
 
@@ -176,7 +176,7 @@ except SummarizerError as e:
 3. **Handle Errors**: Implement proper retry logic for failed requests
 4. **Monitor Usage**: Track your Webshare usage to avoid exceeding limits
 5. **Secure Credentials**: Store proxy credentials in environment variables, not code
-6. **Test First**: Use `setup_proxy_test.py` to verify your configuration
+6. **Test First**: Use `tests/integration/proxy/test_proxy_setup.py` to verify your configuration
 
 ## Troubleshooting
 
@@ -201,7 +201,7 @@ except SummarizerError as e:
 
 ```bash
 # Test proxy configuration
-python setup_proxy_test.py
+python tests/integration/proxy/test_proxy_setup.py
 
 # Test CLI with proxy
 tldwatch --webshare-username "user" --webshare-password "pass" --video-id "QAgR4uQ15rc"
@@ -225,7 +225,7 @@ python examples/complete_proxy_example.py
 For issues:
 1. Check Webshare account status and billing
 2. Verify proxy credentials
-3. Test with `setup_proxy_test.py`
+3. Test with `tests/integration/proxy/test_proxy_setup.py`
 4. Review error messages for specific guidance
 5. Check tldwatch logs for detailed error information
 

--- a/tests/integration/proxy/__init__.py
+++ b/tests/integration/proxy/__init__.py
@@ -1,0 +1,1 @@
+"""Proxy integration tests."""

--- a/tests/integration/proxy/test_proxy_integration.py
+++ b/tests/integration/proxy/test_proxy_integration.py
@@ -12,7 +12,7 @@ import asyncio
 from pathlib import Path
 
 # Add src to path for testing
-sys.path.insert(0, str(Path(__file__).parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
 
 from tldwatch import (
     Summarizer,

--- a/tests/integration/proxy/test_proxy_setup.py
+++ b/tests/integration/proxy/test_proxy_setup.py
@@ -11,7 +11,7 @@ import asyncio
 from pathlib import Path
 
 # Add src to path for testing
-sys.path.insert(0, str(Path(__file__).parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
 
 from tldwatch import create_webshare_proxy, Summarizer, ProxyConfigError
 


### PR DESCRIPTION
# Move proxy server tests to tests/integration/proxy/ directory

## Summary
This PR reorganizes the proxy-related test files by moving them from the root directory to the appropriate location within the `tests/` directory structure.

## Changes Made

### File Moves
- **Moved** `test_proxy_integration.py` → `tests/integration/proxy/test_proxy_integration.py`
- **Moved** `setup_proxy_test.py` → `tests/integration/proxy/test_proxy_setup.py`
- **Created** `tests/integration/proxy/__init__.py` for proper package structure

### Code Updates
- Updated import paths in both test files to work correctly from their new locations
- Modified `sys.path.insert()` statements to reference the correct relative paths to the `src/` directory

### Documentation Updates
- Updated all references in `PROXY_INTEGRATION_SUMMARY.md` to point to new test file locations
- Updated all references in `WEBSHARE_INTEGRATION.md` to point to new test file locations
- Updated command examples and file listings in documentation

## Benefits
- ✅ **Better Organization**: Tests are now properly organized within the `tests/` directory structure
- ✅ **Consistent Structure**: Follows the existing pattern of `tests/integration/` and `tests/unit/` subdirectories
- ✅ **Logical Grouping**: Proxy-related tests are grouped together in their own subdirectory
- ✅ **Maintainability**: Easier to find and maintain proxy-related tests
- ✅ **Test Discovery**: Better integration with test runners that expect tests in the `tests/` directory

## Testing
- ✅ Verified both test files run correctly from their new locations
- ✅ All import paths work as expected
- ✅ Test functionality remains unchanged
- ✅ Documentation references are accurate

## Backward Compatibility
- ✅ No breaking changes to the main codebase
- ✅ Only test file locations and documentation have been updated
- ✅ All existing functionality remains intact

The proxy integration tests are now properly organized and follow the repository's testing conventions.

@smith-nathanh can click here to [continue refining the PR](https://app.all-hands.dev/conversations/dcc5638a66564318ad209536e198a025)